### PR TITLE
SLING-9793 - Allow a default configuration for Jackson exporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,16 +77,7 @@
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
@@ -136,6 +127,47 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.osgi-mock.junit5</artifactId>
+            <version>3.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.logging-mock</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
+
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.junit</groupId>
+          <artifactId>junit-bom</artifactId>
+          <version>5.8.2</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
 
 </project>

--- a/src/main/java/org/apache/sling/models/jacksonexporter/impl/JacksonExporter.java
+++ b/src/main/java/org/apache/sling/models/jacksonexporter/impl/JacksonExporter.java
@@ -136,20 +136,20 @@ public class JacksonExporter implements ModelExporter {
     private ObjectMapper getDefaultMapper() {
         ObjectMapper mapper = new ObjectMapper();
 
-        for (String optionKey : mappingOptions.keySet()) {
-            if (optionKey.startsWith(SERIALIZATION_FEATURE_PREFIX)) {
-                String enumName = optionKey.substring(SERIALIZATION_FEATURE_PREFIX_LENGTH);
+        for (Map.Entry<String, String> option: mappingOptions.entrySet()) {
+            if (option.getKey().startsWith(SERIALIZATION_FEATURE_PREFIX)) {
+                String enumName = option.getKey().substring(SERIALIZATION_FEATURE_PREFIX_LENGTH);
                 try {
                     SerializationFeature feature = SerializationFeature.valueOf(enumName);
-                    mapper.configure(feature, Boolean.parseBoolean(mappingOptions.get(optionKey)));
+                    mapper.configure(feature, Boolean.parseBoolean(option.getValue()));
                 } catch (IllegalArgumentException e) {
                     log.warn("Bad SerializationFeature option");
                 }
-            } else if (optionKey.startsWith(MAPPER_FEATURE_PREFIX)) {
-                String enumName = optionKey.substring(MAPPER_FEATURE_PREFIX_LENGTH);
+            } else if (option.getKey().startsWith(MAPPER_FEATURE_PREFIX)) {
+                String enumName = option.getKey().substring(MAPPER_FEATURE_PREFIX_LENGTH);
                 try {
                     MapperFeature feature = MapperFeature.valueOf(enumName);
-                    mapper.configure(feature, Boolean.parseBoolean(mappingOptions.get(optionKey)));
+                    mapper.configure(feature, Boolean.parseBoolean(option.getValue()));
                 } catch (IllegalArgumentException e) {
                     log.warn("Bad MapperFeature option");
                 }

--- a/src/main/java/org/apache/sling/models/jacksonexporter/impl/JacksonExporter.java
+++ b/src/main/java/org/apache/sling/models/jacksonexporter/impl/JacksonExporter.java
@@ -88,7 +88,7 @@ public class JacksonExporter implements ModelExporter {
                     MapperFeature feature = MapperFeature.valueOf(enumName);
                     mapper.configure(feature, Boolean.valueOf(optionEntry.getValue()));
                 } catch (IllegalArgumentException e) {
-                    log.warn("Bad SerializationFeature option");
+                    log.warn("Bad MapperFeature option");
                 }
             }
         }
@@ -151,7 +151,7 @@ public class JacksonExporter implements ModelExporter {
                     MapperFeature feature = MapperFeature.valueOf(enumName);
                     mapper.configure(feature, Boolean.parseBoolean(mappingOptions.get(optionKey)));
                 } catch (IllegalArgumentException e) {
-                    log.warn("Bad SerializationFeature option");
+                    log.warn("Bad MapperFeature option");
                 }
             }
         }

--- a/src/main/java/org/apache/sling/models/jacksonexporter/impl/PropertiesUtil.java
+++ b/src/main/java/org/apache/sling/models/jacksonexporter/impl/PropertiesUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.models.jacksonexporter.impl;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+
+final class PropertiesUtil {
+
+    private PropertiesUtil() {
+        // static methods only
+    }
+
+    /**
+     * Returns the parameter as a map with string keys and string values.
+     *
+     * The parameter is considered as a collection whose entries are of the form
+     * key=value. The conversion has following rules
+     * <ul>
+     *     <li>Entries are of the form key=value</li>
+     *     <li>key and value are trimmed.</li>
+     *     <li>Malformed entries like 'foo','foo=' are ignored</li>
+     *     <li>Map entries maintain the input order</li>
+     * </ul>
+     *
+     * @param arrayValue The array to be converted to map.
+     * @return Map value
+     */
+    static Map<String, String> toMap(String @NotNull [] stringArray) {
+        //in property values
+        Map<String, String> result = new LinkedHashMap<>();
+        for (String kv : stringArray) {
+            if (kv == null) {
+                continue;
+            }
+            int indexOfEqual = kv.indexOf('=');
+            if (indexOfEqual > 0) {
+                String key = StringUtils.trimToNull(kv.substring(0, indexOfEqual));
+                String value = StringUtils.trimToNull(kv.substring(indexOfEqual + 1));
+                if (key != null && value != null) {
+                    result.put(key, value);
+                }
+            }
+        }
+        return result;
+    }
+
+}

--- a/src/test/java/org/apache/sling/models/jacksonexporter/impl/JacksonExporterMappingOptionsTest.java
+++ b/src/test/java/org/apache/sling/models/jacksonexporter/impl/JacksonExporterMappingOptionsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.models.jacksonexporter.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.sling.models.factory.ExportException;
+import org.apache.sling.models.jacksonexporter.impl.example.ExamplePojo;
+import org.apache.sling.testing.mock.osgi.junit5.OsgiContext;
+import org.apache.sling.testing.mock.osgi.junit5.OsgiContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests passing in and configuring mapping options for {@link JacksonExporter}.
+ */
+@ExtendWith(OsgiContextExtension.class)
+class JacksonExporterMappingOptionsTest {
+
+    private OsgiContext context = new OsgiContext();
+
+    private ExamplePojo pojoWithData;
+
+    @BeforeEach
+    void setUp() {
+        pojoWithData = new ExamplePojo()
+                .stringProp("value1")
+                .numberProp(1)
+                .booleanProp(true);
+    }
+
+    @Test
+    void testDefaultConfig() throws ExportException {
+        JacksonExporter underTest = context.registerInjectActivateService(JacksonExporter.class);
+        Map<String,String> options = Collections.emptyMap();
+
+        String expectedJson = "{\"stringProp\":\"value1\",\"numberProp\":1,\"booleanProp\":true}";
+        assertEquals(expectedJson, underTest.export(pojoWithData, String.class, options));
+    }
+
+    @Test
+    void testPassedInOptions() throws ExportException {
+        JacksonExporter underTest = context.registerInjectActivateService(JacksonExporter.class);
+        Map<String,String> options = Collections.singletonMap("MapperFeature.SORT_PROPERTIES_ALPHABETICALLY", "true");
+
+        String expectedJson = "{\"booleanProp\":true,\"numberProp\":1,\"stringProp\":\"value1\"}";
+        assertEquals(expectedJson, underTest.export(pojoWithData, String.class, options));
+    }
+
+    @Test
+    void testConfiguredOptions() throws ExportException {
+        JacksonExporter underTest = context.registerInjectActivateService(JacksonExporter.class,
+                "mapping.options", new String[] { "MapperFeature.SORT_PROPERTIES_ALPHABETICALLY=true" });
+        Map<String,String> options = Collections.emptyMap();
+
+        String expectedJson = "{\"booleanProp\":true,\"numberProp\":1,\"stringProp\":\"value1\"}";
+        assertEquals(expectedJson, underTest.export(pojoWithData, String.class, options));
+    }
+
+    @Test
+    void testPassedInOptionsOverlayConfiguredOptions() throws ExportException {
+        JacksonExporter underTest = context.registerInjectActivateService(JacksonExporter.class,
+                "mapping.options", new String[] { "MapperFeature.SORT_PROPERTIES_ALPHABETICALLY=true" });
+        Map<String,String> options = Collections.singletonMap("MapperFeature.SORT_PROPERTIES_ALPHABETICALLY", "false");
+
+        String expectedJson = "{\"stringProp\":\"value1\",\"numberProp\":1,\"booleanProp\":true}";
+        assertEquals(expectedJson, underTest.export(pojoWithData, String.class, options));
+    }
+
+}

--- a/src/test/java/org/apache/sling/models/jacksonexporter/impl/ModelSkippingSerializersTest.java
+++ b/src/test/java/org/apache/sling/models/jacksonexporter/impl/ModelSkippingSerializersTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.sling.models.jacksonexporter.impl;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
 
@@ -27,35 +27,35 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.Model;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-public class ModelSkippingSerializersTest {
+class ModelSkippingSerializersTest {
 
     private ModelSkippingSerializers serializers = new ModelSkippingSerializers();
     private JavaType nonAnnotatedType = TypeFactory.defaultInstance().constructType(NonAnnotated.class);
     private JavaType annotatedType = TypeFactory.defaultInstance().constructType(Annotated.class);
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         serializers.addSerializer(Resource.class, new ResourceSerializer(-1));
     }
 
     @Test
-    public void testDefaultSerializerAccess() {
+    void testDefaultSerializerAccess() {
         assertTrue(serializers.findSerializer(null, nonAnnotatedType, null) instanceof ResourceSerializer);
     }
 
     @Test
-    public void testAnnotatedNullLookup() {
+    void testAnnotatedNullLookup() {
         assertNull(serializers.findSerializer(null, annotatedType, null));
     }
 
     @Model(adaptables = SlingHttpServletRequest.class)
-    private class Annotated extends AbstractResource {
+    private static class Annotated extends AbstractResource {
 
         @Override
         public String getName() {
@@ -119,7 +119,7 @@ public class ModelSkippingSerializersTest {
         }
     }
 
-    private class NonAnnotated extends AbstractResource {
+    private static class NonAnnotated extends AbstractResource {
 
         @Override
         public String getName() {

--- a/src/test/java/org/apache/sling/models/jacksonexporter/impl/PropertiesUtilTest.java
+++ b/src/test/java/org/apache/sling/models/jacksonexporter/impl/PropertiesUtilTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.models.jacksonexporter.impl;
+
+import static org.apache.sling.models.jacksonexporter.impl.PropertiesUtil.toMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class PropertiesUtilTest {
+
+    @Test
+    void testToMap_EmptyArrray() {
+        assertEquals(Collections.emptyMap(), toMap(new String[0]));
+    }
+
+    @Test
+    void testToMap_VariousEntries() {
+        String[] input = new String[] {
+          "prop1=value1",
+          "  prop.2  =  value.2 ",
+          "prop3=",
+          "prop4",
+          "",
+          null,
+          "prop5=value5a=value5b"
+        };
+
+        Map<String,String> expectedOutput = new LinkedHashMap<>();
+        expectedOutput.put("prop1", "value1");
+        expectedOutput.put("prop.2", "value.2");
+        expectedOutput.put("prop5", "value5a=value5b");
+
+        assertEquals(expectedOutput, toMap(input));
+    }
+
+}

--- a/src/test/java/org/apache/sling/models/jacksonexporter/impl/example/ExamplePojo.java
+++ b/src/test/java/org/apache/sling/models/jacksonexporter/impl/example/ExamplePojo.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.models.jacksonexporter.impl.example;
+
+public class ExamplePojo {
+
+    private String stringProp;
+    private Integer numberProp;
+    private Boolean booleanProp;
+
+    public String getStringProp() {
+        return stringProp;
+    }
+
+    public ExamplePojo stringProp(String value) {
+        this.stringProp = value;
+        return this;
+    }
+
+    public Integer getNumberProp() {
+        return numberProp;
+    }
+
+    public ExamplePojo numberProp(Integer value) {
+        this.numberProp = value;
+        return this;
+    }
+
+    public Boolean getBooleanProp() {
+        return booleanProp;
+    }
+
+    public ExamplePojo booleanProp(Boolean value) {
+        this.booleanProp = value;
+        return this;
+    }
+
+}


### PR DESCRIPTION
This allows configuring properties like alphabetical ordering of JSON fields system-wide instead of on a per-model basis. Overriding these default configurations per model is still possible.