### PR TITLE
SLING-10964 Sling Models Exporter: Replace RankedServices with DS Field Injection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,12 +99,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.commons.osgi</artifactId>
-            <version>2.4.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>

--- a/src/main/java/org/apache/sling/models/jacksonexporter/impl/JacksonExporter.java
+++ b/src/main/java/org/apache/sling/models/jacksonexporter/impl/JacksonExporter.java
@@ -20,10 +20,9 @@ package org.apache.sling.models.jacksonexporter.impl;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collection;
 import java.util.Map;
 
-import org.apache.sling.commons.osgi.Order;
-import org.apache.sling.commons.osgi.RankedServices;
 import org.apache.sling.models.export.spi.ModelExporter;
 import org.apache.sling.models.factory.ExportException;
 import org.apache.sling.models.jacksonexporter.ModuleProvider;
@@ -56,7 +55,9 @@ public class JacksonExporter implements ModelExporter {
 
     private static final int MAPPER_FEATURE_PREFIX_LENGTH = MAPPER_FEATURE_PREFIX.length();
 
-    private final RankedServices<ModuleProvider> moduleProviders = new RankedServices<>(Order.ASCENDING);
+    @Reference(service = ModuleProvider.class,
+            cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    private volatile Collection<ModuleProvider> moduleProviders;
 
     @Override
     public boolean isSupported(@NotNull Class<?> clazz) {
@@ -119,17 +120,6 @@ public class JacksonExporter implements ModelExporter {
         } else {
             return null;
         }
-    }
-
-    @Reference(name = "moduleProvider", service = ModuleProvider.class,
-            cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC,
-            bind = "bindModuleProvider", unbind = "unbindModuleProvider")
-    protected void bindModuleProvider(final ModuleProvider moduleProvider, final Map<String, Object> props) {
-        moduleProviders.bind(moduleProvider, props);
-    }
-
-    protected void unbindModuleProvider(final ModuleProvider moduleProvider, final Map<String, Object> props) {
-        moduleProviders.unbind(moduleProvider, props);
     }
 
     @Override


### PR DESCRIPTION
this PR does not contain any unit tests because atm all exporter tests are ITs in a separate module https://github.com/apache/sling-org-apache-sling-models-integration-tests

in the existing code the order of ModuleProvider references was not covered, i planned to add a test case for this. but looking deeper into the code turned out that's not that easy - and probably not required. what a ModuleProvider is doing is registering a Jackson "Module" to the ObjectMapper, and this module registry with all their tiny parts (like lists of serializers etc.) has a very complex structure. and each module usually registers to a different class and there usually should not be a conflict if the order is different.

i validated that the integration test cover the case if any of the existing modul provider implementations is missing, and they pass with this change.